### PR TITLE
Add DownloadMagickImages and some fix

### DIFF
--- a/WebImageExtractor/Extensions/UriExtensions.cs
+++ b/WebImageExtractor/Extensions/UriExtensions.cs
@@ -70,12 +70,13 @@ namespace WebImageExtractor.Extensions
         /// <returns>Image extension as <see cref="MagickFormat"/>.</returns>
         public static MagickFormat ToMagickFormat(this Uri uri)
         {
-            string uriString = uri.ToString().ToLower();
+            string uriString = uri.ToString().ToLowerInvariant();
+            string uriStringBody = System.Text.RegularExpressions.Regex.Replace(uriString, @"\?.+$|\#.+$", string.Empty);
 
             Array values = Enum.GetValues(typeof(MagickFormat));
             foreach (MagickFormat value in values)
             {
-                if (uriString.EndsWith($".{Enum.GetName(typeof(MagickFormat), value).ToLower()}"))
+                if (uriString.EndsWith($".{Enum.GetName(typeof(MagickFormat), value).ToLowerInvariant()}") || uriStringBody.EndsWith($".{Enum.GetName(typeof(MagickFormat), value).ToLowerInvariant()}"))
                 {
                     return value;
                 }
@@ -91,9 +92,9 @@ namespace WebImageExtractor.Extensions
         /// <returns>True if image extension supported by Magick.NET.</returns>
         public static bool HasImageExtension(this Uri uri)
         {
-            string uriString = uri.ToString().ToLower();
+            string uriString = uri.ToString().ToLowerInvariant();
             string[] magickFormats = Enum.GetNames(typeof(MagickFormat));
-            return magickFormats.Any(f => !Constants.BadMagickTypes.Contains(f) && uriString.EndsWith($".{f.ToLower()}"));
+            return magickFormats.Any(f => !Constants.BadMagickTypes.Contains(f) && uriString.EndsWith($".{f.ToLowerInvariant()}"));
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace WebImageExtractor.Extensions
         /// <returns>True if image extension is not supported.</returns>
         public static bool IsBadMagickType(this Uri uri)
         {
-            string uriString = uri.ToString().ToLower();
+            string uriString = uri.ToString().ToLowerInvariant();
             return Constants.BadMagickTypes.Any(ts => uriString.EndsWith($".{ts}"));
         }
 
@@ -114,7 +115,7 @@ namespace WebImageExtractor.Extensions
         /// <returns>True if image extension is .svg</returns>
         public static bool HasSvgExtension(this Uri uri)
         {
-            string uriString = uri.ToString().ToLower();
+            string uriString = uri.ToString().ToLowerInvariant();
             return uriString.EndsWith($".svg");
         }
 

--- a/WebImageExtractor/ImageDownloader.cs
+++ b/WebImageExtractor/ImageDownloader.cs
@@ -24,6 +24,66 @@ namespace WebImageExtractor
         /// <returns>Downloaded MagickImage, null if unsuccessful.</returns>
         public static async Task<MagickImage> DownloadMagickImage(Uri uri, CancellationToken cancellationToken)
         {
+            MagickImage image = null;
+            await DownloadAction(uri, cancellationToken, (stream) =>
+            {
+                if (!(stream is null))
+                {
+                    try
+                    {
+                        image = new MagickImage(stream, uri.ToMagickFormat());
+                    }
+                    catch
+                    {
+                        try
+                        {
+                            stream.Seek(0, SeekOrigin.Begin);
+                            image = new MagickImage(stream);
+                        }
+                        catch
+                        {
+                            image = null;
+                        }
+                    }
+                }
+
+                return Task.CompletedTask;
+            });
+            return image;
+        }
+
+        public static async Task<MagickImageCollection> DownloadMagickImages(Uri uri, CancellationToken cancellationToken)
+        {
+            MagickImageCollection image = null;
+            await DownloadAction(uri, cancellationToken, (stream) =>
+            {
+                if (!(stream is null))
+                {
+                    try
+                    {
+                        image = new MagickImageCollection(stream, uri.ToMagickFormat());
+                    }
+                    catch
+                    {
+                        try
+                        {
+                            stream.Seek(0, SeekOrigin.Begin);
+                            image = new MagickImageCollection(stream);
+                        }
+                        catch
+                        {
+                            image = null;
+                        }
+                    }
+                }
+
+                return Task.CompletedTask;
+            });
+            return image;
+        }
+
+        public static async Task DownloadAction(Uri uri, CancellationToken cancellationToken, Func<Stream, Task> action)
+        {
             if (Extractor.ExtractionSettings == null)
             {
                 Extractor.ExtractionSettings = new ExtractionSettings();
@@ -49,14 +109,12 @@ namespace WebImageExtractor
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    return null;
+                    await action?.Invoke(null);
                 }
 
                 using (Stream stream = await response.Content.ReadAsStreamAsync())
                 {
-                    MagickImage image = null;
-                    image = new MagickImage(stream, uri.ToMagickFormat());
-                    return image;
+                    await action?.Invoke(stream);
                 }
             }
         }

--- a/WebImageExtractor/Recurser.cs
+++ b/WebImageExtractor/Recurser.cs
@@ -152,7 +152,7 @@ namespace WebImageExtractor
                         return null;
                     }
 
-                    await Task.WhenAll(images.Select(i => i.GetImageAsync(cancellationToken)).ToArray());
+                    await Task.WhenAll(images.Select(i => i.GetImagesAsync(cancellationToken)).ToArray());
                 }
 
                 if (settings.OnFoundImage != null)


### PR DESCRIPTION
To keep compatibility, I added new methods for MagickImageCollection instead of replacing.

This PR includes other small fixes.
* Use ToLowerInvariant() instead of ToLower().
  * `ToLower()` returns weird value in some culture. Ex. In "tr-TR", `"I".ToLower()` returns `ı`.
  * Microsoft Docs says `Use the String.ToUpperInvariant method instead of the String.ToLowerInvariant method when you normalize strings for comparison` [here](https://docs.microsoft.com/ja-jp/dotnet/standard/base-types/best-practices-strings).  So maybe I should've used `ToUpperInvariant()` instead.
* Support for URL like `icon.png?size=32`.
* Add `try{}catch{}`. I encountered too many Exceptions.

They are not tested enough and some methods have been added in my sense. Please test and modify it to match the project policy. 